### PR TITLE
Install Boost in GitHub CI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         sudo add-apt-repository ppa:mhier/libboost-latest -y
         sudo apt-get update
-        sudo apt-get install libboost-all-dev -y
+        sudo apt-get install libboost1.70 libboost1.70-dev -y
     - name: configure
       run: |
         mkdir build 


### PR DESCRIPTION
Created step in the C++ CI action to download a (recent enough, 1.70) copy of Boost. This is necessary in order to compile and test the program.

Usually, `apt` repositories are a few versions behind the latest Boost release. Because this project needs at least Boost 1.66 (because of Beast), a custom PPA was added. 

In the future, a solution installing Boost from the source should be used. Consider checking [this CMake file](https://gist.github.com/thiagowfx/970e3931387ed7db9a39709a8a130ee9).