### PR TITLE
Send response when InputEvent is received

### DIFF
--- a/client/ClientWS.js
+++ b/client/ClientWS.js
@@ -17,7 +17,7 @@ export class ClientWS {
             console.log("OPEN");
         };
         this.ws.onmessage = (ev) => {
-            console.log(ev);
+            console.log(ev.data);
         };
     }
 

--- a/src/Events/Draw.hpp
+++ b/src/Events/Draw.hpp
@@ -13,7 +13,7 @@ class Draw final : public OutputEvent {
     }
 
    public:
-    const Card& card;
+    const Card card;
 
     Draw(const Card& card_)
         : OutputEvent(Type::Draw),

--- a/src/Events/JoinMatchResult.hpp
+++ b/src/Events/JoinMatchResult.hpp
@@ -17,13 +17,10 @@ class JoinMatchResult final : public PlayerResult {
    public:
     std::string matchID;
 
-    JoinMatchResult(const std::string& nickname_,
-                    const std::string& matchID_)
-        : PlayerResult(Type::JoinMatchResult, nickname_),
-          matchID(matchID_) {}
+    JoinMatchResult(const std::string& nickname_)
+        : PlayerResult(Type::JoinMatchResult, nickname_) {}
 
     // Does not check if the JoinMatchRequest is valid
     explicit JoinMatchResult(const JoinMatchRequest& o)
-        : PlayerResult(Type::JoinMatchResult, o.nickname),
-          matchID(o.matchID) {}
+        : PlayerResult(Type::JoinMatchResult, o.nickname) {}
 };

--- a/src/Events/MatchInfo.hpp
+++ b/src/Events/MatchInfo.hpp
@@ -20,9 +20,9 @@ class MatchInfo final : public OutputEvent {
     }
 
    public:
-    const MatchConfig& config;
-    const std::vector<Player>& players;
-    const Deck& deck;
+    const MatchConfig config;
+    const std::vector<Player> players;
+    const Deck deck;
 
     MatchInfo(const MatchConfig& config_,
               const std::vector<Player>& players_,

--- a/src/Game/Match.cpp
+++ b/src/Game/Match.cpp
@@ -145,9 +145,10 @@ void Match::removePlayer(const std::string& nickname) {
     }
 }
 
-void Match::start() {
+std::unique_ptr<const OutputEvent> Match::start() {
     currentPhase = Phase::GameStart;
     processPhase();
+    return std::move(updateEvent);
 }
 
 std::unique_ptr<const OutputEvent> Match::handleInputEvent(const InputEvent* action) {

--- a/src/Game/Match.hpp
+++ b/src/Game/Match.hpp
@@ -17,8 +17,17 @@
 
 class Match {
    private:
+    // Contains updates caused by an InputEvent
+    // After processing the InputEvent, ${updateEvent} gets sent to the clients
+    std::unique_ptr<OutputEvent> updateEvent = nullptr;
     int currentAttack = 0;  // Max attack used for the current card
     int currentOffer = 0;   // Max gold offered for the current card
+
+    // Adds ${event} to th current &{updateEvent}
+    void addEvent(std::unique_ptr<const OutputEvent> event);
+
+    // Sets &{updateEvent} to an error state
+    void setError(const std::string& message);
 
     // Get player index by nickname
     unsigned int getPlayerIndex(const std::string& nickname) const;
@@ -74,7 +83,7 @@ class Match {
     void start();
 
     // Process InputEvent and return OutputEvent with update of the Match's state
-    // Returns invalid event if there is no valid update in the state
+    // Returns Error if there is no valid update in the state
     std::unique_ptr<const OutputEvent> handleInputEvent(const InputEvent* action);
 
     // Methods for each Phase in the game

--- a/src/Game/Match.hpp
+++ b/src/Game/Match.hpp
@@ -24,7 +24,7 @@ class Match {
     int currentOffer = 0;   // Max gold offered for the current card
 
     // Adds ${event} to th current &{updateEvent}
-    void addEvent(std::unique_ptr<const OutputEvent> event);
+    void addEvent(std::unique_ptr<OutputEvent> event);
 
     // Sets &{updateEvent} to an error state
     void setError(const std::string& message);

--- a/src/Game/Match.hpp
+++ b/src/Game/Match.hpp
@@ -79,8 +79,9 @@ class Match {
     // Remove player from the match
     void removePlayer(const std::string& nickname);
 
-    // Start the game, process until the match ends
-    void start();
+    // Start the game
+    // Returns OutputEvent with the game state changes during the start
+    std::unique_ptr<const OutputEvent> start();
 
     // Process InputEvent and return OutputEvent with update of the Match's state
     // Returns Error if there is no valid update in the state

--- a/src/Game/MatchHandler.cpp
+++ b/src/Game/MatchHandler.cpp
@@ -49,17 +49,16 @@ void MatchHandler::notifyPlayers(const std::shared_ptr<const OutputEvent>& event
     }
 }
 
-// Receive an InputEvent from a client
-void MatchHandler::handleInputEvent(const InputEvent* action) {
+std::unique_ptr<const OutputEvent> MatchHandler::handleInputEvent(const InputEvent* action) {
     auto event = match.handleInputEvent(action);
-    // If there is an update in the state of match, broadcast it
-    if (!event->isError()) {
-        std::shared_ptr<const OutputEvent> s = std::move(event);
-        notifyPlayers(std::move(s));
-    } else {
-        // If the input was invalid, send the error to the client who sent it
-        //TODO
+    // If the input was invalid, send the error to the client who sent it
+    if (event->isError()) {
+        return std::move(event);
     }
+    // If there is an update in the state of match, broadcast it
+    std::shared_ptr<const OutputEvent> s = std::move(event);
+    notifyPlayers(std::move(s));
+    return nullptr;
 }
 
 bool MatchHandler::isRunning() const {

--- a/src/Game/MatchHandler.hpp
+++ b/src/Game/MatchHandler.hpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <string>
 
+#include "Events/MatchInfo.hpp"
 #include "Match.hpp"
 
 class IOHandler;
@@ -17,6 +18,9 @@ class MatchHandler {
     // Inform every player about the OutputEvent
     void notifyPlayers(const std::shared_ptr<const OutputEvent>& event);
 
+    // Returns MatchInfo from the current match
+    std::unique_ptr<const MatchInfo> getMatchInfo() const;
+
    public:
     //TODO consider making private and using a factory to create Match
 
@@ -26,10 +30,10 @@ class MatchHandler {
     MatchHandler(const MatchConfig& config, const Deck& deck);
 
     // Add a new player to the match
-    // True if the player was inserted
-    // False if the nickname already exists, match is full or running
-    bool addPlayer(IOHandler* client,
-                   const std::string& nickname);
+    // Returns MatchInfo if successfully joined
+    // Returs Error if nickname already exists, match is full or running
+    std::unique_ptr<const OutputEvent> addPlayer(IOHandler* client,
+                                                 const std::string& nickname);
 
     // Remove player from the match
     void removePlayer(const std::string& nickname);
@@ -37,7 +41,8 @@ class MatchHandler {
     // Returns the amount of connected players
     std::size_t getPlayerCount() const;
 
-    // Start the game, process until the match ends
+    // Start the game
+    // Notifies the players of the game state changes
     void start();
 
     // Receive a InputEvent from a client

--- a/src/Game/MatchHandler.hpp
+++ b/src/Game/MatchHandler.hpp
@@ -41,7 +41,9 @@ class MatchHandler {
     void start();
 
     // Receive a InputEvent from a client
-    void handleInputEvent(const InputEvent* action);
+    // If there is a valid state update, returns nullptr
+    // If the InputEvent is invalid, returns a pointer with Error
+    std::unique_ptr<const OutputEvent> handleInputEvent(const InputEvent* action);
 
     // True if the match is running
     bool isRunning() const;

--- a/src/IO/WebsocketSession.cpp
+++ b/src/IO/WebsocketSession.cpp
@@ -81,7 +81,7 @@ void WebsocketSession::onRead(error_code ec, std::size_t) {
     doRead();
 }
 
-void WebsocketSession::send(std::shared_ptr<std::string const> const& ss) {
+void WebsocketSession::send(const std::shared_ptr<const std::string>& ss) {
     // Add message to queue
     queue.push_back(ss);
 

--- a/src/IO/WebsocketSession.hpp
+++ b/src/IO/WebsocketSession.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <cstdlib>
+#include <deque>
 #include <memory>
 #include <string>
-#include <deque>
 
-#include "WebsocketHandler.hpp"
-#include "Beast.hpp"
 #include "Asio.hpp"
+#include "Beast.hpp"
+#include "WebsocketHandler.hpp"
 
 //TODO implement BaseWebsocket using template method to define what to do when a message is received
 class WebsocketSession : public std::enable_shared_from_this<WebsocketSession> {
@@ -40,5 +40,5 @@ class WebsocketSession : public std::enable_shared_from_this<WebsocketSession> {
     bool isOpen() const;
 
     // Send a message
-    void send(std::shared_ptr<std::string const> const& ss);
+    void send(const std::shared_ptr<const std::string>& ss);
 };

--- a/src/Parsing/JSONParser.cpp
+++ b/src/Parsing/JSONParser.cpp
@@ -165,7 +165,6 @@ boost::property_tree::ptree outputEventToTree(const OutputEvent* event) {
             case OT::JoinMatchResult: {
                 const auto joinMatchResult = static_cast<const JoinMatchResult*>(event);
                 pt.put("nickname", joinMatchResult->nickname);
-                pt.put("matchID", joinMatchResult->matchID);
             } break;
             case OT::AttackResult: {
                 const auto attackResult = static_cast<const AttackResult*>(event);

--- a/src/Parsing/JSONParser.hpp
+++ b/src/Parsing/JSONParser.hpp
@@ -22,7 +22,7 @@ namespace JSONParser {
 
 // Returns unique_ptr with the event in JSON
 // Output messages:
-//  {"type": "joinMatch", "nickname": "XXX", "matchID": "XXX"}
+//  {"type": "joinMatch", "nickname": "XXX"}
 //  {"type": "attack", "nickname": "XXX"}
 //  {"type": "offer", "nickname": "XXX", "gold": int}
 //  {"type": "pass", "nickname": "XXX"}

--- a/test/testJSONParser.cpp
+++ b/test/testJSONParser.cpp
@@ -176,12 +176,11 @@ TEST_CASE("Test JSONParser::outputEventToMessage", "[parser]") {
     };
 
     SECTION("JoinMatch") {
-        JoinMatchResult joinMatch("Player1", "Match123");
+        JoinMatchResult joinMatch("Player1");
         const auto message = JSONParser::outputEventToMessage(&joinMatch);
         const auto pt = parseJSON(*message);
         REQUIRE(pt.get<std::string>("type") == "joinMatch");
         REQUIRE(pt.get<std::string>("nickname") == "Player1");
-        REQUIRE(pt.get<std::string>("matchID") == "Match123");
     }
 
     SECTION("Attack") {


### PR DESCRIPTION
Fixes #25 
This PR handles any received `InputEvent` with an `OutputEvent`, be it a game state update or an `Error` for a single client.

Some new events must still be added (`Discard` and `Tie`, for example, if a better choice is not found). Also, for now the client only prints the received JSON message on the console, but does not get updated in any other way.