### PR TITLE
Update Catch2 automatic install option

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -18,6 +18,12 @@ jobs:
         sudo add-apt-repository ppa:mhier/libboost-latest -y
         sudo apt-get update
         sudo apt-get install libboost1.70 libboost1.70-dev -y
+    - name: Install Catch2
+      run: |
+        git clone https://github.com/catchorg/Catch2.git
+        cd Catch2
+        cmake -Bbuild -H. -DBUILD_TESTING=OFF
+        sudo cmake --build build/ --target install
     - name: configure
       run: |
         mkdir build 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Based on the real [*Espada Negra: juego de mesa*](https://espadanegra.net/jdm.ph
   - Tested with `gcc 7.5.0`.
 - At least `CMake 3.11`.
 - At least [`Boost 1.66`](https://www.boost.org/users/download/) (needs the `Asio`, `Beast` and `Property Tree` libraries).
-- [`Catch2`](https://github.com/catchorg/Catch2). There is a CMake script that downloads it automatically if it is not found.
+- [`Catch2`](https://github.com/catchorg/Catch2). The `PrepareCatch2.cmake` script downloads it automatically if not found, if the `INSTALL_CATCH2` option is set.
 
 ## Compile
 ```

--- a/cmake/PrepareCatch2.cmake
+++ b/cmake/PrepareCatch2.cmake
@@ -1,23 +1,26 @@
 cmake_minimum_required(VERSION 3.11)
+option(INSTALL_CATCH2 "Automatically install Catch2" FALSE)
 
-find_package(Catch2 QUIET)
+find_package(Catch2 REQUIRED)
 if(TARGET Catch2::Catch2)
   message("Catch2 found")
 else()
-  message("Catch2 NOT found, downloading...")
+  message("Catch2 NOT found")
+  if(INSTALL_CATCH2)
+    message("Downloading Catch2...")
+    include(FetchContent)
+    FetchContent_Declare(
+      catch2
+      GIT_REPOSITORY https://github.com/catchorg/Catch2
+      GIT_TAG master
+    )
 
-  include(FetchContent)
-  FetchContent_Declare(
-    catch2
-    GIT_REPOSITORY https://github.com/catchorg/Catch2
-    GIT_TAG master
-  )
-
-  FetchContent_GetProperties(catch2)
-  if (NOT catch2_POPULATED)
-    FetchContent_Populate(catch2)
-    add_subdirectory(${catch2_SOURCE_DIR} ${catch2_BINARY_DIR})
-    list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+    FetchContent_GetProperties(catch2)
+    if (NOT catch2_POPULATED)
+      FetchContent_Populate(catch2)
+      add_subdirectory(${catch2_SOURCE_DIR} ${catch2_BINARY_DIR})
+      list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+    endif()
   endif()
 endif()
 include(Catch)


### PR DESCRIPTION
Previously, Catch2 was installed by default if it was not found. There is now an option to enable or disable the automatic installation. The CI has been updated accordingly.